### PR TITLE
Change hyphenated corrections to camelCase

### DIFF
--- a/identifier_typo_test.go
+++ b/identifier_typo_test.go
@@ -178,6 +178,38 @@ func Test_processIdentifiers(t *testing.T) {
 				},
 			},
 		},
+		{name: "misspelled function with no receiver which is corrected by hyphenation",
+			args: args{
+				testFiles: []*testFile{
+					{
+						src: `package main
+						func Alltime() {
+						}`,
+						name:     "file.go",
+						wantLogs: []string{"file.go:2 \"Alltime\" should be AllTime in Alltime\n"},
+					},
+				},
+				flags: Flags{
+					Ignores: "",
+				},
+			},
+		},
+		{name: "misspelled (unexported) function with no receiver which is corrected by hyphenation",
+			args: args{
+				testFiles: []*testFile{
+					{
+						src: `package main
+						func alltime() {
+						}`,
+						name:     "file.go",
+						wantLogs: []string{"file.go:2 \"alltime\" should be allTime in alltime\n"},
+					},
+				},
+				flags: Flags{
+					Ignores: "",
+				},
+			},
+		},
 		{name: "single misspelled function matching ignore",
 			args: args{
 				testFiles: []*testFile{


### PR DESCRIPTION
I'm not sure if this is a welcome change or not, but I've noticed that this tool is sometimes suggesting changing identifiers to include hyphens (which is obviously not valid).

My original solution to this was just to ignore any replacements including hyphens, however it seems a nicer way might be to convert them into camelCase instead.

See the tests I've changed for an example of how this works.